### PR TITLE
stream_data can accept specific jsonl_key

### DIFF
--- a/lm_dataformat/__init__.py
+++ b/lm_dataformat/__init__.py
@@ -124,9 +124,9 @@ class Reader:
     def __init__(self, in_path):
         self.in_path = in_path
     
-    def stream_data(self, get_meta=False, threaded=False):
+    def stream_data(self, get_meta=False, threaded=False, jsonl_key='text'):
         if not threaded:
-            yield from self._stream_data(get_meta)
+            yield from self._stream_data(get_meta=get_meta, jsonl_key=jsonl_key)
             return
 
         q = mp.Queue(1000)


### PR DESCRIPTION
lm_dataformat is called in [preprocess_data.py](https://github.com/EleutherAI/gpt-neox/blob/f5ce8f1c5a1693a754f4eb1fa7aceb1eb45dd3ea/tools/preprocess_data.py#L146-L162) to process a given jsonl file. Current it can only process the specific "text" key even if `--json_keys` is defined as something else.

proposed changes so that the key taken from the json file matches --json_keys. 

